### PR TITLE
Init Express project with real‑time WebSocket chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# shadowChat1.0.0
-A snappy fast chat platform that also works on air gaped computer systems
+# ShadowChat 1.0.0
+
+This repository contains a simple real-time chat application built with **Node.js** and **Express**. The front end lives in the `/client` directory while all server code resides in `/server`.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+This runs the Express server on port `3001` and the Vite development server on port `5173`. The client connects to the server using Socket.IO.
+
+## Production build
+
+To create a production build of the client run:
+
+```bash
+npm run build
+```
+
+After building, the Express server can serve the compiled files from the `dist` directory.
+

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { createServer } from 'http';
-import { Server } from 'socket.io';
+// The WebSocket logic is extracted to a separate module
+import { setupSocket, getStats } from './socket.js';
 import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -10,136 +11,31 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 const server = createServer(app);
-const io = new Server(server, {
-  cors: {
-    origin: "http://localhost:5173",
-    methods: ["GET", "POST"]
-  }
-});
+// Initialize WebSocket handling
+setupSocket(server);
 
 // Middleware
 app.use(cors());
 app.use(express.json());
 
-// Store active users and messages in memory (for air-gapped systems)
-const activeUsers = new Map();
-const chatHistory = [];
-const MAX_HISTORY = 100; // Limit chat history for performance
-
-// Socket.IO connection handling
-io.on('connection', (socket) => {
-  console.log(`User connected: ${socket.id}`);
-
-  // Handle user joining
-  socket.on('user_join', (userData) => {
-    const user = {
-      id: socket.id,
-      username: userData.username || `User_${socket.id.slice(0, 6)}`,
-      joinedAt: new Date().toISOString()
-    };
-    
-    activeUsers.set(socket.id, user);
-    
-    // Send chat history to new user
-    socket.emit('chat_history', chatHistory);
-    
-    // Broadcast user list update
-    io.emit('users_update', Array.from(activeUsers.values()));
-    
-    // Broadcast join message
-    const joinMessage = {
-      id: Date.now(),
-      type: 'system',
-      content: `${user.username} joined the chat`,
-      timestamp: new Date().toISOString()
-    };
-    
-    io.emit('new_message', joinMessage);
-    addToHistory(joinMessage);
-  });
-
-  // Handle new messages
-  socket.on('send_message', (messageData) => {
-    const user = activeUsers.get(socket.id);
-    if (!user) return;
-
-    const message = {
-      id: Date.now(),
-      type: 'user',
-      content: messageData.content,
-      username: user.username,
-      userId: socket.id,
-      timestamp: new Date().toISOString()
-    };
-
-    // Broadcast message to all clients
-    io.emit('new_message', message);
-    addToHistory(message);
-  });
-
-  // Handle typing indicators
-  socket.on('typing_start', () => {
-    const user = activeUsers.get(socket.id);
-    if (user) {
-      socket.broadcast.emit('user_typing', { username: user.username, isTyping: true });
-    }
-  });
-
-  socket.on('typing_stop', () => {
-    const user = activeUsers.get(socket.id);
-    if (user) {
-      socket.broadcast.emit('user_typing', { username: user.username, isTyping: false });
-    }
-  });
-
-  // Handle disconnection
-  socket.on('disconnect', () => {
-    const user = activeUsers.get(socket.id);
-    if (user) {
-      activeUsers.delete(socket.id);
-      
-      // Broadcast user list update
-      io.emit('users_update', Array.from(activeUsers.values()));
-      
-      // Broadcast leave message
-      const leaveMessage = {
-        id: Date.now(),
-        type: 'system',
-        content: `${user.username} left the chat`,
-        timestamp: new Date().toISOString()
-      };
-      
-      io.emit('new_message', leaveMessage);
-      addToHistory(leaveMessage);
-    }
-    
-    console.log(`User disconnected: ${socket.id}`);
-  });
-});
-
-// Helper function to manage chat history
-function addToHistory(message) {
-  chatHistory.push(message);
-  if (chatHistory.length > MAX_HISTORY) {
-    chatHistory.shift(); // Remove oldest message
-  }
-}
 
 // API endpoints for air-gapped functionality
 app.get('/api/health', (req, res) => {
-  res.json({ 
-    status: 'online', 
-    users: activeUsers.size,
-    messages: chatHistory.length,
+  const stats = getStats();
+  res.json({
+    status: 'online',
+    users: stats.users,
+    messages: stats.messages,
     timestamp: new Date().toISOString()
   });
 });
 
 app.get('/api/export-chat', (req, res) => {
+  const stats = getStats();
   res.json({
     exportedAt: new Date().toISOString(),
-    totalMessages: chatHistory.length,
-    messages: chatHistory
+    totalMessages: stats.messages,
+    messages: stats.history
   });
 });
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,103 @@
+import { Server } from 'socket.io';
+
+// In-memory store for connected users and chat history
+const activeUsers = new Map();
+const chatHistory = [];
+const MAX_HISTORY = 100;
+
+export function setupSocket(server) {
+  const io = new Server(server, {
+    cors: {
+      origin: 'http://localhost:5173',
+      methods: ['GET', 'POST'],
+    },
+  });
+
+  io.on('connection', socket => {
+    console.log(`User connected: ${socket.id}`);
+
+    socket.on('user_join', userData => {
+      const user = {
+        id: socket.id,
+        username: userData.username || `User_${socket.id.slice(0, 6)}`,
+        joinedAt: new Date().toISOString(),
+      };
+      activeUsers.set(socket.id, user);
+
+      socket.emit('chat_history', chatHistory);
+      io.emit('users_update', Array.from(activeUsers.values()));
+
+      const joinMessage = {
+        id: Date.now(),
+        type: 'system',
+        content: `${user.username} joined the chat`,
+        timestamp: new Date().toISOString(),
+      };
+      io.emit('new_message', joinMessage);
+      addToHistory(joinMessage);
+    });
+
+    socket.on('send_message', messageData => {
+      const user = activeUsers.get(socket.id);
+      if (!user) return;
+
+      const message = {
+        id: Date.now(),
+        type: 'user',
+        content: messageData.content,
+        username: user.username,
+        userId: socket.id,
+        timestamp: new Date().toISOString(),
+      };
+      io.emit('new_message', message);
+      addToHistory(message);
+    });
+
+    socket.on('typing_start', () => {
+      const user = activeUsers.get(socket.id);
+      if (user) {
+        socket.broadcast.emit('user_typing', { username: user.username, isTyping: true });
+      }
+    });
+
+    socket.on('typing_stop', () => {
+      const user = activeUsers.get(socket.id);
+      if (user) {
+        socket.broadcast.emit('user_typing', { username: user.username, isTyping: false });
+      }
+    });
+
+    socket.on('disconnect', () => {
+      const user = activeUsers.get(socket.id);
+      if (user) {
+        activeUsers.delete(socket.id);
+        io.emit('users_update', Array.from(activeUsers.values()));
+        const leaveMessage = {
+          id: Date.now(),
+          type: 'system',
+          content: `${user.username} left the chat`,
+          timestamp: new Date().toISOString(),
+        };
+        io.emit('new_message', leaveMessage);
+        addToHistory(leaveMessage);
+      }
+      console.log(`User disconnected: ${socket.id}`);
+    });
+  });
+
+  function addToHistory(message) {
+    chatHistory.push(message);
+    if (chatHistory.length > MAX_HISTORY) {
+      chatHistory.shift();
+    }
+  }
+}
+
+export function getStats() {
+  return {
+    users: activeUsers.size,
+    messages: chatHistory.length,
+    history: chatHistory,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated `setupSocket` helper that wires Socket.IO to the HTTP server
- refactor `server/index.js` to use the new helper
- expose endpoints using stats from the socket module
- expand `README` with quick start instructions

## Testing
- `npm run build` *(fails: Rollup failed to resolve import)*

------
https://chatgpt.com/codex/tasks/task_e_685b3060e75c8327bd27e5ff1848bf5d