### PR TITLE
Integrate Supabase database

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,22 @@ npm run build
 
 After building, the Express server can serve the compiled files from the `dist` directory.
 
+## Database configuration
+
+The server can persist data to a Supabase instance. Set the following environment
+variables before starting the server:
+
+```
+SUPABASE_URL=<your supabase url>
+SUPABASE_KEY=<your supabase anon key>
+```
+
+SQL definitions for the required tables can be found in `server/db/schema.sql`.
+
+## API
+
+Additional endpoints are available:
+
+- `GET /api/chat-history` – retrieve full chat history from the database.
+- `POST /api/users/:id/profile-image` – store a user's profile image (base64 string) in the database.
+

--- a/server/config/supabase.js
+++ b/server/config/supabase.js
@@ -1,0 +1,24 @@
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.warn('Supabase credentials are not configured');
+}
+
+export async function supabaseFetch(path, options = {}) {
+  const url = `${SUPABASE_URL}${path}`;
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      apikey: SUPABASE_KEY,
+      Authorization: `Bearer ${SUPABASE_KEY}`,
+      'Content-Type': 'application/json',
+      ...(options.headers || {})
+    }
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Supabase request failed: ${text}`);
+  }
+  return res.json();
+}

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -1,0 +1,15 @@
+-- SQL schema for Supabase tables
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL,
+  profile_image TEXT,
+  joined_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  user_id TEXT REFERENCES users(id),
+  username TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/server/models/messages.js
+++ b/server/models/messages.js
@@ -1,0 +1,14 @@
+import { supabaseFetch } from '../config/supabase.js';
+
+export async function saveMessage(message) {
+  return supabaseFetch('/rest/v1/messages', {
+    method: 'POST',
+    body: JSON.stringify(message)
+  });
+}
+
+export async function getChatHistory() {
+  return supabaseFetch('/rest/v1/messages?select=*&order=created_at', {
+    method: 'GET'
+  });
+}

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -1,0 +1,16 @@
+import { supabaseFetch } from '../config/supabase.js';
+
+export async function upsertUser(user) {
+  return supabaseFetch('/rest/v1/users', {
+    method: 'POST',
+    headers: { Prefer: 'resolution=merge-duplicates' },
+    body: JSON.stringify(user)
+  });
+}
+
+export async function updateProfileImage(id, imageData) {
+  return supabaseFetch(`/rest/v1/users?id=eq.${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ profile_image: imageData })
+  });
+}


### PR DESCRIPTION
## Summary
- connect to Supabase using a simple fetch helper
- model `users` and `messages` for database operations
- persist messages and users from the websocket server
- expose new API endpoints `/api/chat-history` and `/api/users/:id/profile-image`
- document database setup and API usage

## Testing
- `node --check server/index.js`
- `node --check server/socket.js`
- `node --check server/models/messages.js`
- `node --check server/models/users.js`


------
https://chatgpt.com/codex/tasks/task_e_685b339fd8d48327ade471255cea9e46