### PR TITLE
Fix websocket origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ variables before starting the server:
 ```
 SUPABASE_URL=<your supabase url>
 SUPABASE_KEY=<your supabase anon key>
+CLIENT_ORIGIN=<origin allowed for websocket connections> # defaults to '*'
 ```
 
 SQL definitions for the required tables can be found in `server/db/schema.sql`.

--- a/server/socket.js
+++ b/server/socket.js
@@ -10,7 +10,7 @@ const MAX_HISTORY = 100;
 export function setupSocket(server) {
   const io = new Server(server, {
     cors: {
-      origin: 'http://localhost:5173',
+      origin: process.env.CLIENT_ORIGIN || '*',
       methods: ['GET', 'POST'],
     },
   });


### PR DESCRIPTION
## Summary
- relax socket CORS check by reading env var
- document CLIENT_ORIGIN env var

## Testing
- `npm test` *(fails: Missing script)*
- `node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_685b37be327c8327b369bd63022aca92