### PR TITLE
Load chat history from database on start

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -93,6 +93,8 @@ class ShadowChat {
     this.socket.on('chat_history', (messages) => {
       this.clearWelcomeMessage();
       messages.forEach(message => this.displayMessage(message));
+      this.messageCount = messages.length;
+      this.messageCountEl.textContent = this.messageCount;
       this.scrollToBottom();
     });
 


### PR DESCRIPTION
## Summary
- load existing chat history from Supabase when the websocket server starts
- update message count when initial history loads

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b39d2e54c8327a3b830fad39e492f