### PR TITLE
Make socket endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ variables before starting the server:
 SUPABASE_URL=<your supabase url>
 SUPABASE_KEY=<your supabase anon key>
 CLIENT_ORIGIN=<origin allowed for websocket connections> # defaults to '*'
+VITE_SOCKET_URL=<url for socket.io client>            # optional
 ```
+
+`VITE_SOCKET_URL` allows overriding the default WebSocket endpoint
+used by the front end. When omitted, the client connects to the same
+origin that served the page.
 
 SQL definitions for the required tables can be found in `server/db/schema.sql`.
 

--- a/client/main.js
+++ b/client/main.js
@@ -69,8 +69,10 @@ class ShadowChat {
   }
 
   connectToServer() {
-    // Connect to the chat server
-    this.socket = io('http://localhost:3001', {
+    // Connect to the chat server. Use the VITE_SOCKET_URL environment
+    // variable when provided, otherwise default to the current origin.
+    const url = import.meta.env.VITE_SOCKET_URL || window.location.origin;
+    this.socket = io(url, {
       transports: ['websocket', 'polling']
     });
 


### PR DESCRIPTION
## Summary
- add `VITE_SOCKET_URL` support so the socket.io client connects to the right host in production
- document new variable in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b3daeac288327b43aa93a2ea28733